### PR TITLE
save to filesystem, don't store in memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # multi-user-dev-server
 
-Create a webpack dev server that supports multiple users (or configs) on one port.
+This creates a web service that runs `webpack --watch` for multiple users/configs. It can be controlled by a simple web API.
 
 ## Example
 
@@ -10,29 +10,40 @@ Try `example/app.js` with
 npm install
 npm start
 
-open localhost:8080/user1/bundle.js
-open localhost:8080/user2/bundle.js
+open localhost:8080/user1
+open localhost:8080/user2
 ```
 
 ## Usage
 
 ```js
 const multiUserDevServer = require('multi-user-dev-server');
-const app = multiUserDevServer(user => `/home/${user}/repo/webpack.config.js`);
+
+const app = multiUserDevServer(username => {
+  return {
+    // The path to this user's webpack config
+    configPath: `${__dirname}/${username}/webpack.config.js`,
+    // The `env` to pass into the webpack config
+    webpackEnv: {},
+    // What to respond with for `GET /:username` (optional)
+    successResponse: `Bundle completed in ${__dirname}/${username}`,
+  };
+});
+
 app.listen(8080);
 ```
 
 ## Server API
 
-Get a bundle
+Start building `username`'s webpack bundle. If it's already building, this will wait to respond until building is complete.
 
 ```
-GET /:username/:bundle-name
+GET /:username
 ```
 
 
-Reload one user's webpack config
+Reload `username`'s webpack config.
 
 ```
-POST /reload/:username
+POST :username
 ```

--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ Try `example/app.js` with
 npm install
 npm start
 
-open localhost:8080/user1
-open localhost:8080/user2
+curl --data '' http://localhost:8080/bundle/user1
+curl --data '' http://localhost:8080/bundle/user2
+
+curl --data '' http://localhost:8080/reload/user1
+curl --data '' http://localhost:8080/reload/user2
 ```
 
 ## Usage
@@ -35,15 +38,15 @@ app.listen(8080);
 
 ## Server API
 
-Start building `username`'s webpack bundle. If it's already building, this will wait to respond until building is complete.
+Start building `username`'s webpack bundle and wait until it completes. If it's already building, this will wait to respond until building is complete.
 
 ```
-GET /:username
+POST /bundle/:username
 ```
 
 
 Reload `username`'s webpack config.
 
 ```
-POST :username
+POST /reload/:username
 ```

--- a/example/app.js
+++ b/example/app.js
@@ -1,6 +1,14 @@
 const multiUserDevServer = require('../multi-user-dev-server.js');
 
-const app = multiUserDevServer(username =>
-    `${__dirname}/${username}/webpack.config.js`);
+const app = multiUserDevServer(username => {
+  return {
+    // The path to this user's webpack config
+    configPath: `${__dirname}/${username}/webpack.config.js`,
+    // The `env` to pass into the webpack config
+    webpackEnv: {},
+    // What to respond with for `GET /:username` (optional)
+    successResponse: `Bundle completed in ${__dirname}/${username}`,
+  };
+});
 
 app.listen(8080);

--- a/example/user1/webpack.config.js
+++ b/example/user1/webpack.config.js
@@ -2,6 +2,7 @@ module.exports = (env) => {
   return {
     entry: `${__dirname}/entry.js`,
     output: {
+      path: __dirname,
       filename: 'bundle.js'
     }
   };

--- a/example/user2/webpack.config.js
+++ b/example/user2/webpack.config.js
@@ -2,6 +2,7 @@ module.exports = (env) => {
   return {
     entry: `${__dirname}/entry.js`,
     output: {
+      path: __dirname,
       filename: 'bundle.js'
     },
     devtool: 'inline-sourcemap'

--- a/multi-user-dev-server.js
+++ b/multi-user-dev-server.js
@@ -1,55 +1,75 @@
 const fs = require("fs");
-const Webpack = require("webpack");
+const webpack = require("webpack");
 const Express = require("express");
-const DevMiddleware = require("webpack-dev-middleware");
 
 /**
- * This creates a webpack dev server that supports multiple users (configs) on
- * one port.
+ * This creates a simple web service that runs `webpack --watch` for multiple
+ * users/configs. It can be controlled by a simple web API.
  *
- * This server can be accessed with
- *   GET /:username/:bundle-name
+ * Build a user's bundle, or wait until it is done bundling
+ *   GET /:username
  *
- * An individual user's webpack config can be reloaded with
- *   POST /reload/:username
+ * Reload a user's webpack config
+ *   POST /:username
  *
- * @param usernameToConfigPath A function that takes a username and returns a
- *                             a path to that user's webpack config.
+ * @param optionsFromUsername A function that takes a username and returns a
+ *                            options for multi-user-dev-server. See sample in
+ *                            example/app.js.
  * @return Express App
  */
-function createDevServer(usernameToConfigPath) {
+function createDevServer(optionsFromUsername) {
   const app = Express();
 
-  // Map of username -> DevMiddleware for the currently loaded webpack configs.
-  const devMiddlewares = {};
+  // Map of username -> { compiler, watching, whenDone }
+  const compilers = {};
 
   /**
-   * Given a username of a user on the dev machine, this returns a DevMiddleware
-   * instance for that user.
+   * Given a username of a user on the dev machine, this returns an object with:
+   *   compiler: a webpack compiler instance
+   *   watching: a watching instance from calling compiler.watch()
+   *   whenDone: returns a promise that resolves when the user's bundle is done
    *
-   * @param string username A username, such that usernameToConfigPath(username)
-   *                        returns username's webpack config.
-   * @return Middleware This middleware will respond with built js bundles.
+   * @param string username A username, will be used in optionsFromUsername()
+   *
+   * @return { compiler, watching, whenDone }
    */
-  const getDevMiddlewareForUsername = username => {
+  const getUserCompiler = username => {
     if (!/^[\w\-_]+$/.test(username)) {
       throw new Error('invalid characters in username');
     }
 
-    const configPath = usernameToConfigPath(username);
+    const options = optionsFromUsername(username);
 
     // Hack: Make sure that node loads the most up-to-date version of the
     // user's webpack config, since it may have changed since this server
     // started.
-    delete require.cache[require.resolve(configPath)];
-    const getWebpackConfig = require(configPath);
+    delete require.cache[require.resolve(options.configPath)];
+    const getWebpackConfig = require(options.configPath);
+    const compiler = webpack(getWebpackConfig(options.webpackEnv || {}));
 
-    const config = getWebpackConfig();
+    // `whenDone` will add pending promises to this list, which will be resolved
+    // when the `watching` handler gets called.
+    let promises = [];
 
-    return DevMiddleware(Webpack(config), {
-      publicPath: '/' + username,
-      contentBase: false
+    const watching = compiler.watch({}, (err, stats) => {
+      // resolve and clear all the promises added by `whenDone`.
+      promises.forEach(({ resolve, reject }) => err ? reject(err) : resolve());
+      promises = [];
+
+      // logging
+      const endDateString = new Date(stats.endTime * 1000).toISOString();
+      console.log(`${username} bundled at ${endDateString}`);
     });
+
+    const whenDone = () => new Promise((resolve, reject) => {
+      if (!watching.running) {
+        resolve();
+      } else {
+        promises.push({ resolve, reject });
+      }
+    });
+
+    return { compiler, watching, whenDone };
   }
 
   /**
@@ -62,20 +82,32 @@ function createDevServer(usernameToConfigPath) {
    */
   const reloadConfig = forceReload => {
     return (req, res, next) => {
-      if (!forceReload && devMiddlewares[req.username]) {
-        return next();
-      }
-
       try {
-        devMiddlewares[req.username] = getDevMiddlewareForUsername(req.username);
+        if (compilers[req.username]) {
+          // This user's config has already been loaded.
+          if (!forceReload) {
+            // If we're not forcing a reload, continue.
+            return next();
+          } else {
+            // If we are forcing a reload, cancel the filesystem watching from
+            // the old compiler.
+            compilers[req.username].watching.close(() =>
+              console.log(`${req.username}'s config reloaded`));
+          }
+        }
+
+        compilers[req.username] = getUserCompiler(req.username, forceReload);
         next();
       } catch (e) {
-        devMiddlewares[req.username] = null;
+        compilers[req.username] = null;
         res.status(500);
         res.send('Reload failed: ' + e.message);
       }
     };
   }
+
+  const timeoutPromise = timeout =>
+    new Promise(resolve => setTimeout(resolve, timeout));
 
   app.param('username', (req, res, next, username) => {
     req.username = username;
@@ -85,19 +117,33 @@ function createDevServer(usernameToConfigPath) {
   /**
    * This endpoint reloads the webpack configuration for `username`.
    */
-  app.post('/reload/:username', reloadConfig(true), (req, res, next) => {
+  app.post('/:username', reloadConfig(true), (req, res, next) => {
     res.status(201);
     res.send('devServer reloaded\n');
   });
 
   /**
-   * This endpoint returns a built js bundle for `/username/bundle-name.js`.
+   * This endpoint responds when username's bundle has finished being bundled.
    */
-  app.get('/:username/*', reloadConfig(false), (req, res, next) => {
-    // Note: we can't attach this middleware with `app.use` because there
-    // is no way to remove it later. We need to replace it when the user
-    // reloads their config.
-    devMiddlewares[req.username](req, res, next);
+  app.get('/:username', reloadConfig(false), (req, res, next) => {
+    const options = optionsFromUsername(req.username);
+    const bundleDone = compilers[req.username].whenDone();
+
+    // After 20 seconds, respond with a 500 and tell the user to wait longer.
+    // That way, they know why it's taking so long.
+    const timeoutDone = timeoutPromise(20000).then(() =>
+      Promise.reject("Bundle still building, try refreshing"));
+
+    Promise.race([
+      timeoutDone,
+      bundleDone,
+    ]).then(() => {
+      res.status(200);
+      res.send(options.successResponse || 'bundle built');
+    }, err => {
+      res.status(500);
+      res.send(err);
+    });
   });
 
   return app;

--- a/multi-user-dev-server.js
+++ b/multi-user-dev-server.js
@@ -6,11 +6,11 @@ const Express = require("express");
  * This creates a simple web service that runs `webpack --watch` for multiple
  * users/configs. It can be controlled by a simple web API.
  *
- * Build a user's bundle, or wait until it is done bundling
- *   GET /:username
+ * Build a user's bundle and wait until it is done bundling
+ *   POST /bundle/:username
  *
  * Reload a user's webpack config
- *   POST /:username
+ *   POST /reload/:username
  *
  * @param optionsFromUsername A function that takes a username and returns a
  *                            options for multi-user-dev-server. See sample in
@@ -117,7 +117,7 @@ function createDevServer(optionsFromUsername) {
   /**
    * This endpoint reloads the webpack configuration for `username`.
    */
-  app.post('/:username', reloadConfig(true), (req, res, next) => {
+  app.post('/reload/:username', reloadConfig(true), (req, res, next) => {
     res.status(201);
     res.send('devServer reloaded\n');
   });
@@ -125,7 +125,7 @@ function createDevServer(optionsFromUsername) {
   /**
    * This endpoint responds when username's bundle has finished being bundled.
    */
-  app.get('/:username', reloadConfig(false), (req, res, next) => {
+  app.post('/bundle/:username', reloadConfig(false), (req, res, next) => {
     const options = optionsFromUsername(req.username);
     const bundleDone = compilers[req.username].whenDone();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,8 @@
 {
-  "requires": true,
+  "name": "multi-user-dev-server",
+  "version": "1.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "accepts": {
       "version": "1.3.4",
@@ -2697,11 +2699,6 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
       "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
     },
-    "time-stamp": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
-      "integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c="
-    },
     "timers-browserify": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
@@ -2873,18 +2870,6 @@
         "watchpack": "1.4.0",
         "webpack-sources": "1.0.1",
         "yargs": "8.0.2"
-      }
-    },
-    "webpack-dev-middleware": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz",
-      "integrity": "sha1-007++y7dp+HTtdvgcolRMhllFwk=",
-      "requires": {
-        "memory-fs": "0.4.1",
-        "mime": "1.3.4",
-        "path-is-absolute": "1.0.1",
-        "range-parser": "1.2.0",
-        "time-stamp": "2.0.0"
       }
     },
     "webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -5,15 +5,14 @@
   "description": "Create a webpack dev server that supports multiple users (or configs) on one port.",
   "license": "MIT",
   "repository": {
-  	"type" : "git",
-  	"url" : "https://github.com/iFixit/multi-user-dev-server"
+    "type": "git",
+    "url": "https://github.com/iFixit/multi-user-dev-server"
   },
   "dependencies": {
     "express": "^4.15.4",
-    "webpack": "^3.6.0",
-    "webpack-dev-middleware": "^1.12.0"
+    "webpack": "^3.6.0"
   },
   "scripts": {
-  	"start": "node example/app.js"
+    "start": "node example/app.js"
   }
 }


### PR DESCRIPTION
Summary
---

We were using up a lot of memory with the old implementation. Since we're just saving them to disk in the asset build process, let's save them to disk in the first place.

How?
---

Stop using `webpack-dev-middleware`. Use the standard `webpack` API which can `watch()` for changes. This writes the bundles to disk.

Still include the web API, but only use it for starting a bundle, reloading a config, and checking if a bundle is completed yet.