### PR TITLE
Webpack Instances: expire after X seconds of unuse

### DIFF
--- a/compiler-collection.js
+++ b/compiler-collection.js
@@ -1,4 +1,4 @@
-modules.exports = () => {
+module.exports = () => {
   const compilers = new Map();
 
   return {

--- a/compiler-collection.js
+++ b/compiler-collection.js
@@ -1,0 +1,14 @@
+modules.exports = () => {
+  const compilers = {}
+
+  return {
+    get: (username) => compilers[username],
+    set: (username, compiler) => compilers[username] = compiler,
+    remove: (username) => {
+      const compiler = compilers[username];
+      if (!compiler) return;
+      compiler.watching.close();
+      delete compilers[username];
+    }
+  }
+}

--- a/compiler-collection.js
+++ b/compiler-collection.js
@@ -1,12 +1,20 @@
 module.exports = () => {
   const compilers = new Map();
 
+  function updateLastAccessed(username) {
+    const compiler = compilers.get(username)
+    if (!compiler) return;
+    compiler.lastAccessed = Date.now();
+  }
+
   return {
     get: (username) => {
+      updateLastAccessed(username)
       return compilers.get(username)
     },
     set: (username, compiler) => {
       compilers.set(username, compiler)
+      updateLastAccessed(username)
     },
     remove: (username) => {
       const compiler = compilers.get(username);

--- a/compiler-collection.js
+++ b/compiler-collection.js
@@ -1,5 +1,24 @@
-module.exports = () => {
+module.exports = (expireAfterSeconds) => {
+  const expireMs = expireAfterSeconds * 1000;
   const compilers = new Map();
+
+  if (expireAfterSeconds) {
+    setInterval(removeExpiredCompilers, 30 * 1000);
+  }
+
+  function removeExpiredCompilers() {
+    compilers.forEach((compiler, username) => {
+      if (isExpired(compiler)) {
+        console.log(`${username}: bundle was unused for ${expireAfterSeconds} seoncds, expiring.`);
+        interface.remove(username);
+      }
+    })
+  }
+
+  function isExpired(compiler) {
+    const oldestAllowedAccessTime = Date.now() - expireMs;
+    return compiler.lastAccessed < oldestAllowedAccessTime;
+  }
 
   function updateLastAccessed(username) {
     const compiler = compilers.get(username)
@@ -7,7 +26,7 @@ module.exports = () => {
     compiler.lastAccessed = Date.now();
   }
 
-  return {
+  const interface = {
     get: (username) => {
       updateLastAccessed(username)
       return compilers.get(username)
@@ -23,4 +42,6 @@ module.exports = () => {
       compilers.delete(username);
     }
   }
+
+  return interface;
 }

--- a/compiler-collection.js
+++ b/compiler-collection.js
@@ -1,14 +1,14 @@
 modules.exports = () => {
-  const compilers = {}
+  const compilers = new Map();
 
   return {
-    get: (username) => compilers[username],
-    set: (username, compiler) => compilers[username] = compiler,
+    get: (username) => compilers.get(username),
+    set: (username, compiler) => compilers.set(username, compiler),
     remove: (username) => {
-      const compiler = compilers[username];
+      const compiler = compilers.get(username);
       if (!compiler) return;
       compiler.watching.close();
-      delete compilers[username];
+      compilers.delete(username);
     }
   }
 }

--- a/compiler-collection.js
+++ b/compiler-collection.js
@@ -2,8 +2,12 @@ module.exports = () => {
   const compilers = new Map();
 
   return {
-    get: (username) => compilers.get(username),
-    set: (username, compiler) => compilers.set(username, compiler),
+    get: (username) => {
+      return compilers.get(username)
+    },
+    set: (username, compiler) => {
+      compilers.set(username, compiler)
+    },
     remove: (username) => {
       const compiler = compilers.get(username);
       if (!compiler) return;

--- a/example/app.js
+++ b/example/app.js
@@ -9,6 +9,6 @@ const app = multiUserDevServer(username => {
     // What to respond with for `GET /:username` (optional)
     successResponse: `Bundle completed in ${__dirname}/${username}`,
   };
-});
+}, /* expireAfter */ 10);
 
 app.listen(8080);

--- a/multi-user-dev-server.js
+++ b/multi-user-dev-server.js
@@ -16,13 +16,16 @@ const CompilerCollection = require("./compiler-collection.js");
  * @param optionsFromUsername A function that takes a username and returns a
  *                            options for multi-user-dev-server. See sample in
  *                            example/app.js.
+ * @param expireUnusedAfterSeconds Number of seconds after which webpack
+ *                            watchers that are unused will be closed /
+ *                            released. 0 or null == no expiration.
  * @return Express App
  */
-function createDevServer(optionsFromUsername) {
+function createDevServer(optionsFromUsername, expireUnusedAfterSeconds) {
   const app = Express();
 
   // Map of username -> { compiler, watching, whenDone }
-  const compilers = CompilerCollection();
+  const compilers = CompilerCollection(expireUnusedAfterSeconds);
 
   /**
    * Given a username of a user on the dev machine, this returns an object with:

--- a/multi-user-dev-server.js
+++ b/multi-user-dev-server.js
@@ -96,7 +96,7 @@ function createDevServer(optionsFromUsername) {
           }
         }
 
-        compilers[req.username] = getUserCompiler(req.username, forceReload);
+        compilers[req.username] = getUserCompiler(req.username);
         next();
       } catch (e) {
         compilers[req.username] = null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-user-dev-server",
-  "version": "1.0.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-user-dev-server",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "multi-user-dev-server.js",
   "description": "Create a webpack dev server that supports multiple users (or configs) on one port.",
   "license": "MIT",


### PR DESCRIPTION
This was done to prevent the always-growing memory 
of providing one webpack instance per user.

The theory was that any user who loaded one page on their
domain would have their webpack config / instance taking up RAM and
watching i-nodes forever more. unless we do something like this.

CC @djmetzle

Closes #4