### PR TITLE
Multi-user: use forking!

### DIFF
--- a/compiler-collection.js
+++ b/compiler-collection.js
@@ -1,4 +1,4 @@
-modules.exports = () => {
+module.exports = () => {
   const compilers = new Map();
 
   return {

--- a/compiler-collection.js
+++ b/compiler-collection.js
@@ -10,7 +10,7 @@ module.exports = (expireAfterSeconds) => {
     compilers.forEach((compiler, username) => {
       if (isExpired(compiler)) {
         console.log(`${username}: bundle was unused for ${expireAfterSeconds} seconds, expiring.`);
-        interface.remove(username);
+        collection.remove(username);
       }
     })
   }
@@ -26,7 +26,7 @@ module.exports = (expireAfterSeconds) => {
     compiler.lastAccessed = Date.now();
   }
 
-  const interface = {
+  const collection = {
     get: (username) => {
       updateLastAccessed(username)
       return compilers.get(username)
@@ -43,5 +43,5 @@ module.exports = (expireAfterSeconds) => {
     }
   }
 
-  return interface;
+  return collection;
 }

--- a/compiler-collection.js
+++ b/compiler-collection.js
@@ -1,0 +1,14 @@
+modules.exports = () => {
+  const compilers = {}
+
+  return {
+    get: (username) => compilers[username],
+    set: (username, compiler) => compilers[username] = compiler,
+    remove: (username) => {
+      const compiler = compilers[username];
+      if (!compiler) return;
+      compiler.watching.close();
+      delete compilers[username];
+    }
+  }
+}

--- a/compiler-collection.js
+++ b/compiler-collection.js
@@ -1,12 +1,20 @@
 module.exports = () => {
   const compilers = new Map();
 
+  function updateLastAccessed(username) {
+    const compiler = compilers.get(username)
+    if (!compiler) return;
+    compiler.lastAccessed = Date.now();
+  }
+
   return {
     get: (username) => {
+      updateLastAccessed(username)
       return compilers.get(username)
     },
     set: (username, compiler) => {
       compilers.set(username, compiler)
+      updateLastAccessed(username)
     },
     remove: (username) => {
       const compiler = compilers.get(username);

--- a/compiler-collection.js
+++ b/compiler-collection.js
@@ -1,5 +1,24 @@
-module.exports = () => {
+module.exports = (expireAfterSeconds) => {
+  const expireMs = expireAfterSeconds * 1000;
   const compilers = new Map();
+
+  if (expireAfterSeconds) {
+    setInterval(removeExpiredCompilers, 30 * 1000);
+  }
+
+  function removeExpiredCompilers() {
+    compilers.forEach((compiler, username) => {
+      if (isExpired(compiler)) {
+        console.log(`${username}: bundle was unused for ${expireAfterSeconds} seoncds, expiring.`);
+        interface.remove(username);
+      }
+    })
+  }
+
+  function isExpired(compiler) {
+    const oldestAllowedAccessTime = Date.now() - expireMs;
+    return compiler.lastAccessed < oldestAllowedAccessTime;
+  }
 
   function updateLastAccessed(username) {
     const compiler = compilers.get(username)
@@ -7,7 +26,7 @@ module.exports = () => {
     compiler.lastAccessed = Date.now();
   }
 
-  return {
+  const interface = {
     get: (username) => {
       updateLastAccessed(username)
       return compilers.get(username)
@@ -23,4 +42,6 @@ module.exports = () => {
       compilers.delete(username);
     }
   }
+
+  return interface;
 }

--- a/compiler-collection.js
+++ b/compiler-collection.js
@@ -8,8 +8,10 @@ module.exports = (expireAfterSeconds) => {
        return;
     }
     clearTimeout(compiler.expiredTimeout);
-    compiler.expiredTimeout = setTimeout(() => collection.remove(username), expireMs);
-    console.log(`${username}: bundle was unused for ${expireAfterSeconds} seconds, expiring.`);
+    compiler.expiredTimeout = setTimeout(() => {
+       collection.remove(username)
+       console.log(`${username}: bundle was unused for ${expireAfterSeconds} seconds, expiring.`);
+    }, expireMs);
   }
 
   const collection = {

--- a/compiler-collection.js
+++ b/compiler-collection.js
@@ -2,40 +2,24 @@ module.exports = (expireAfterSeconds) => {
   const expireMs = expireAfterSeconds * 1000;
   const compilers = new Map();
 
-  if (expireAfterSeconds) {
-    // Check for expired things often enough to expire things within
-    // 20% of their true expiration time.
-    setInterval(removeExpiredCompilers, expireAfterSeconds / 5);
-  }
-
-  function removeExpiredCompilers() {
-    compilers.forEach((compiler, username) => {
-      if (isExpired(compiler)) {
-        console.log(`${username}: bundle was unused for ${expireAfterSeconds} seconds, expiring.`);
-        collection.remove(username);
-      }
-    })
-  }
-
-  function isExpired(compiler) {
-    const oldestAllowedAccessTime = Date.now() - expireMs;
-    return compiler.lastAccessed < oldestAllowedAccessTime;
-  }
-
-  function updateLastAccessed(username) {
+  function resetExpireTimeout(username) {
     const compiler = compilers.get(username)
-    if (!compiler) return;
-    compiler.lastAccessed = Date.now();
+    if (!compiler || !expireMs) {
+       return;
+    }
+    clearTimeout(compiler.expiredTimeout);
+    compiler.expiredTimeout = setTimeout(() => collection.remove(username), expireMs);
+    console.log(`${username}: bundle was unused for ${expireAfterSeconds} seconds, expiring.`);
   }
 
   const collection = {
     get: (username) => {
-      updateLastAccessed(username)
+      resetExpireTimeout(username)
       return compilers.get(username)
     },
     set: (username, compiler) => {
       compilers.set(username, compiler)
-      updateLastAccessed(username)
+      resetExpireTimeout(username)
     },
     remove: (username) => {
       const compiler = compilers.get(username);

--- a/compiler-collection.js
+++ b/compiler-collection.js
@@ -1,14 +1,14 @@
 modules.exports = () => {
-  const compilers = {}
+  const compilers = new Map();
 
   return {
-    get: (username) => compilers[username],
-    set: (username, compiler) => compilers[username] = compiler,
+    get: (username) => compilers.get(username),
+    set: (username, compiler) => compilers.set(username, compiler),
     remove: (username) => {
-      const compiler = compilers[username];
+      const compiler = compilers.get(username);
       if (!compiler) return;
       compiler.watching.close();
-      delete compilers[username];
+      compilers.delete(username);
     }
   }
 }

--- a/compiler-collection.js
+++ b/compiler-collection.js
@@ -2,8 +2,12 @@ module.exports = () => {
   const compilers = new Map();
 
   return {
-    get: (username) => compilers.get(username),
-    set: (username, compiler) => compilers.set(username, compiler),
+    get: (username) => {
+      return compilers.get(username)
+    },
+    set: (username, compiler) => {
+      compilers.set(username, compiler)
+    },
     remove: (username) => {
       const compiler = compilers.get(username);
       if (!compiler) return;

--- a/compiler-collection.js
+++ b/compiler-collection.js
@@ -9,7 +9,7 @@ module.exports = (expireAfterSeconds) => {
   function removeExpiredCompilers() {
     compilers.forEach((compiler, username) => {
       if (isExpired(compiler)) {
-        console.log(`${username}: bundle was unused for ${expireAfterSeconds} seoncds, expiring.`);
+        console.log(`${username}: bundle was unused for ${expireAfterSeconds} seconds, expiring.`);
         interface.remove(username);
       }
     })

--- a/compiler-collection.js
+++ b/compiler-collection.js
@@ -3,7 +3,7 @@ module.exports = (expireAfterSeconds) => {
   const compilers = new Map();
 
   if (expireAfterSeconds) {
-    // Check for expired things often enough to exipre things within
+    // Check for expired things often enough to expire things within
     // 20% of their true expiration time.
     setInterval(removeExpiredCompilers, expireAfterSeconds / 5);
   }

--- a/compiler-collection.js
+++ b/compiler-collection.js
@@ -3,7 +3,9 @@ module.exports = (expireAfterSeconds) => {
   const compilers = new Map();
 
   if (expireAfterSeconds) {
-    setInterval(removeExpiredCompilers, 30 * 1000);
+    // Check for expired things often enough to exipre things within
+    // 20% of their true expiration time.
+    setInterval(removeExpiredCompilers, expireAfterSeconds / 5);
   }
 
   function removeExpiredCompilers() {

--- a/example/app.js
+++ b/example/app.js
@@ -9,6 +9,6 @@ const app = multiUserDevServer(username => {
     // What to respond with for `GET /:username` (optional)
     successResponse: `Bundle completed in ${__dirname}/${username}`,
   };
-});
+}, /* expireAfter */ 10);
 
 app.listen(8080);

--- a/multi-user-dev-server.js
+++ b/multi-user-dev-server.js
@@ -16,13 +16,16 @@ const CompilerCollection = require("./compiler-collection.js");
  * @param optionsFromUsername A function that takes a username and returns a
  *                            options for multi-user-dev-server. See sample in
  *                            example/app.js.
+ * @param expireUnusedAfterSeconds Number of seconds after which webpack
+ *                            watchers that are unused will be closed /
+ *                            released. 0 or null == no expiration.
  * @return Express App
  */
-function createDevServer(optionsFromUsername) {
+function createDevServer(optionsFromUsername, expireUnusedAfterSeconds) {
   const app = Express();
 
   // Map of username -> { compiler, watching, whenDone }
-  const compilers = CompilerCollection();
+  const compilers = CompilerCollection(expireUnusedAfterSeconds);
 
   /**
    * Given a username of a user on the dev machine, this returns an object with:

--- a/multi-user-dev-server.js
+++ b/multi-user-dev-server.js
@@ -1,5 +1,5 @@
 const fs = require("fs");
-const webpack = require("webpack");
+const WebpackWatcher = require("./webpack-watcher.js");
 const Express = require("express");
 const CompilerCollection = require("./compiler-collection.js");
 
@@ -49,7 +49,7 @@ function createDevServer(optionsFromUsername, expireUnusedAfterSeconds) {
     // started.
     delete require.cache[require.resolve(options.configPath)];
     const getWebpackConfig = require(options.configPath);
-    const compiler = webpack(getWebpackConfig(options.webpackEnv || {}));
+    const compiler = WebpackWatcher(getWebpackConfig(options.webpackEnv || {}));
 
     // `whenDone` will add pending promises to this list, which will be resolved
     // when the `watching` handler gets called.

--- a/multi-user-dev-server.js
+++ b/multi-user-dev-server.js
@@ -96,7 +96,7 @@ function createDevServer(optionsFromUsername) {
           }
         }
 
-        compilers[req.username] = getUserCompiler(req.username, forceReload);
+        compilers[req.username] = getUserCompiler(req.username);
         next();
       } catch (e) {
         compilers[req.username] = null;

--- a/multi-user-dev-server.js
+++ b/multi-user-dev-server.js
@@ -44,9 +44,6 @@ function createDevServer(optionsFromUsername, expireUnusedAfterSeconds) {
     const options = optionsFromUsername(username);
     options.username = username;
 
-    // Hack: Make sure that node loads the most up-to-date version of the
-    // user's webpack config, since it may have changed since this server
-    // started.
     const compiler = WebpackWatcher(options);
 
     const watching = compiler.watch({}, (err, stats) => {

--- a/multi-user-dev-server.js
+++ b/multi-user-dev-server.js
@@ -42,6 +42,9 @@ function createDevServer(optionsFromUsername, expireUnusedAfterSeconds) {
     }
 
     const options = optionsFromUsername(username);
+    // Record the username in the options so the watcher can log relevant
+    // messages. The function here is provided by the runner of the app
+    // so we can't depend on them doing this.
     options.username = username;
 
     const compiler = WebpackWatcher(options);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-user-dev-server",
-  "version": "1.0.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-user-dev-server",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "multi-user-dev-server.js",
   "description": "Create a webpack dev server that supports multiple users (or configs) on one port.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multi-user-dev-server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "multi-user-dev-server.js",
   "description": "Create a webpack dev server that supports multiple users (or configs) on one port.",
   "license": "MIT",

--- a/webpack-compiler.js
+++ b/webpack-compiler.js
@@ -1,0 +1,34 @@
+// This module is run via childProcess.fork() and communicates via IPC
+// messages with the parent process.
+const webpack = require("webpack");
+
+var watcher = null;
+
+process.on('message', (message) => {
+   switch (message && message.event) {
+      // {options, watchOptions}
+      case 'watch':
+         if (!watcher) {
+            watcher = getWebpack(message.options, message.watchOptions);
+         }
+         break;
+
+      // The parent is asking if we're in the middle of running (building)
+      case 'isRunning':
+         // If we're not running (building), let them know we're done;
+         // otherwise, they'll find out via the 'built' event.
+         if (!watcher.running) {
+            process.send({event: 'notRunning'});
+         }
+      break;
+   }
+});
+
+function getWebpack(options, watchOptions) {
+   const getWebpackConfig = require(options.configPath);
+   const config = getWebpackConfig(options.webpackEnv || {});
+   return webpack(config).watch(watchOptions, (err, stats) => {
+      // let the parent know we built our bundle
+      process.send({event: 'built', err, stats: {endTime: stats && stats.endTime}});
+   });
+}

--- a/webpack-compiler.js
+++ b/webpack-compiler.js
@@ -17,7 +17,7 @@ process.on('message', (message) => {
       case 'isRunning':
          // If we're not running (building), let them know we're done;
          // otherwise, they'll find out via the 'built' event.
-         if (!watcher.running) {
+         if (watcher && !watcher.running) {
             process.send({event: 'notRunning'});
          }
       break;

--- a/webpack-watcher.js
+++ b/webpack-watcher.js
@@ -1,0 +1,2 @@
+const webpack = require("webpack");
+module.exports = (config) => return webpack(config);

--- a/webpack-watcher.js
+++ b/webpack-watcher.js
@@ -25,7 +25,6 @@ module.exports = (options) => {
    function notifyWatchers(err) {
       if (watchers.length) {
          const success = err ? " has failed" : " has succeeded";
-         console.log("notifying " + watchers.length + " watchers that bundling " + options.username + success);
       }
       watchers.forEach(({resolve, reject}) => err ? reject(err) : resolve());
       watchers.clear();
@@ -40,7 +39,6 @@ module.exports = (options) => {
       whenDone: () => new Promise((resolve, reject) => {
          watchers.add({resolve, reject});
          child.send({event: 'isRunning'})
-         console.log("asking isRunning");
       })
    }
 

--- a/webpack-watcher.js
+++ b/webpack-watcher.js
@@ -37,12 +37,11 @@ module.exports = (options) => {
          child.kill();
          notifyWatchers("Webpack killed before building completed")
       },
-      whenDone: () => {
-         new Promise((resolve, reject) => {
-            watchers.add({resolve, reject});
-            child.send({event: 'isRunning'})
-         })
-      }
+      whenDone: () => new Promise((resolve, reject) => {
+         watchers.add({resolve, reject});
+         child.send({event: 'isRunning'})
+         console.log("asking isRunning");
+      })
    }
 
    return {

--- a/webpack-watcher.js
+++ b/webpack-watcher.js
@@ -4,14 +4,14 @@ module.exports = (options) => {
    console.log("Forking " + options.username);
    const child = childProcess.fork(__dirname + '/webpack-compiler.js')
 
-   let bundledCallback = () => {}
+   let onBundled = () => {}
    let watchers = [];
 
    child.on('message', (message) => {
       switch (message && message.event) {
          // {err, stats}
          case 'built':
-            bundledCallback(message.err, message.stats);
+            onBundled(message.err, message.stats);
             notifyWatchers(message.err);
             break;
 
@@ -50,7 +50,7 @@ module.exports = (options) => {
    return {
       watch: (watchOptions, callback) => {
          child.send({event: 'watch', options, watchOptions});
-         bundledCallback = callback;
+         onBundled = callback;
          return watcher;
       },
    }

--- a/webpack-watcher.js
+++ b/webpack-watcher.js
@@ -1,2 +1,58 @@
+const childProcess = require('child_process');
 const webpack = require("webpack");
-module.exports = (config) => return webpack(config);
+
+module.exports = (options) => {
+   console.log("Forking " + username);
+   const child = childProcess.fork(__dirname + '/webpack-compiler.js')
+
+   let bundledCallback = () => {}
+   let watchers = [];
+
+   child.on('message', (message) => {
+      switch (message && message.event) {
+         // {err, stats}
+         case 'built':
+            bundledCallback(message.err, message.stats);
+            notifyWatchers(message.err);
+            break;
+
+         // If we're not running (building), then there's nothing to wait on.
+         case 'notRunning':
+            notifyWatchers();
+            break;
+      }
+   });
+
+   function notifyWatchers(err) {
+      if (watchers.length) {
+         const success = err ? " has failed" : " has succeeded";
+         console.log("notifying " + watchers.length + " watchers that bundling " + options.username + success);
+      }
+      watchers.forEach(({resolve, reject}) => err ? reject(err) : resolve());
+      watchers = [];
+   }
+
+   function whenDone() {
+      return new Promise((resolve, reject) => {
+         watchers.push({resolve, reject});
+         child.send({event: 'isRunning'})
+      });
+   }
+
+   const watcher = {
+      close: () => {
+         console.log("Killing " + username);
+         child.kill();
+         notifyWatchers()
+      },
+      whenDone
+   }
+
+   return {
+      watch: (watchOptions, callback) => {
+         child.send({event: 'watch', options, watchOptions});
+         bundledCallback = callback;
+         return watcher;
+      },
+   }
+}

--- a/webpack-watcher.js
+++ b/webpack-watcher.js
@@ -1,8 +1,7 @@
 const childProcess = require('child_process');
-const webpack = require("webpack");
 
 module.exports = (options) => {
-   console.log("Forking " + username);
+   console.log("Forking " + options.username);
    const child = childProcess.fork(__dirname + '/webpack-compiler.js')
 
    let bundledCallback = () => {}
@@ -41,7 +40,7 @@ module.exports = (options) => {
 
    const watcher = {
       close: () => {
-         console.log("Killing " + username);
+         console.log("Killing " + options.username);
          child.kill();
          notifyWatchers()
       },

--- a/webpack-watcher.js
+++ b/webpack-watcher.js
@@ -5,7 +5,7 @@ module.exports = (options) => {
    const child = childProcess.fork(__dirname + '/webpack-compiler.js')
 
    let onBundled = () => {}
-   let watchers = [];
+   const watchers = new Set();
 
    child.on('message', (message) => {
       switch (message && message.event) {
@@ -28,12 +28,12 @@ module.exports = (options) => {
          console.log("notifying " + watchers.length + " watchers that bundling " + options.username + success);
       }
       watchers.forEach(({resolve, reject}) => err ? reject(err) : resolve());
-      watchers = [];
+      watchers.clear();
    }
 
    function whenDone() {
       return new Promise((resolve, reject) => {
-         watchers.push({resolve, reject});
+         watchers.add({resolve, reject});
          child.send({event: 'isRunning'})
       });
    }

--- a/webpack-watcher.js
+++ b/webpack-watcher.js
@@ -31,27 +31,25 @@ module.exports = (options) => {
       watchers.clear();
    }
 
-   function whenDone() {
-      return new Promise((resolve, reject) => {
-         watchers.add({resolve, reject});
-         child.send({event: 'isRunning'})
-      });
-   }
-
-   const watcher = {
+   const watchController = {
       close: () => {
          console.log("Killing " + options.username);
          child.kill();
          notifyWatchers()
       },
-      whenDone
+      whenDone: () => {
+         new Promise((resolve, reject) => {
+            watchers.add({resolve, reject});
+            child.send({event: 'isRunning'})
+         })
+      }
    }
 
    return {
       watch: (watchOptions, callback) => {
          child.send({event: 'watch', options, watchOptions});
          onBundled = callback;
-         return watcher;
+         return watchController;
       },
    }
 }

--- a/webpack-watcher.js
+++ b/webpack-watcher.js
@@ -35,7 +35,7 @@ module.exports = (options) => {
       close: () => {
          console.log("Killing " + options.username);
          child.kill();
-         notifyWatchers()
+         notifyWatchers("Webpack killed before building completed")
       },
       whenDone: () => {
          new Promise((resolve, reject) => {


### PR DESCRIPTION
Turns out, webpack uses tons of memory and doesn't seem to release
it after you call watching.close() and null out the reference.

Not exactly sure what's up with that, but process isolation will
save us.

We now run a node process for each user whose webpack dir we want to
watch. We use node's IPC to send messages back and forth between
parent and child.

Noteable things:
* Collection of promises wating for a build has been moved
  into webpack-watcher
* Compiler expiration now kills the whole forked process,
  fully releasing the heap it was using

Closes #4