### PR TITLE
Builds: save and pass along last build error

### DIFF
--- a/multi-user-dev-server.js
+++ b/multi-user-dev-server.js
@@ -129,7 +129,7 @@ function createDevServer(optionsFromUsername, expireUnusedAfterSeconds) {
       res.send(options.successResponse || 'bundle built');
     }, err => {
       res.status(504);
-      res.send(err);
+      res.send(JSON.stringify(err));
     });
   });
 

--- a/webpack-compiler.js
+++ b/webpack-compiler.js
@@ -3,6 +3,7 @@
 const webpack = require("webpack");
 
 var watcher = null;
+let errFromPreviousBuild = null;
 
 process.on('message', (message) => {
    switch (message && message.event) {
@@ -18,7 +19,7 @@ process.on('message', (message) => {
          // If we're not running (building), let them know we're done;
          // otherwise, they'll find out via the 'built' event.
          if (watcher && !watcher.running) {
-            process.send({event: 'notRunning'});
+            process.send({event: 'notRunning', err: errFromPreviousBuild});
          }
       break;
    }
@@ -30,5 +31,6 @@ function getWebpack(options, watchOptions) {
    return webpack(config).watch(watchOptions, (err, stats) => {
       // let the parent know we built our bundle
       process.send({event: 'built', err, stats: {endTime: stats && stats.endTime}});
+      errFromPreviousBuild = err;
    });
 }

--- a/webpack-watcher.js
+++ b/webpack-watcher.js
@@ -17,7 +17,7 @@ module.exports = (options) => {
 
          // If we're not running (building), then there's nothing to wait on.
          case 'notRunning':
-            notifyWatchers();
+            notifyWatchers(message.err);
             break;
       }
    });


### PR DESCRIPTION
If the webpack wasn't currently building, we'd assume it built
successfully. The affect was this pattern:

Webpack: building ...
Client Req1: > Is the build ready? -> blocking...
Webpack: finished! and failed!
Client Req1: < Finished and failed!

Client Req2: > Is the build ready?
Client Req2: < Finished and Succeeded!

We ended up lying about the success state of the build.

Now, we store the resultant error after every build finishes
and send that along each time a client asks.