### PR TITLE
Errors: send more detailed info back

### DIFF
--- a/multi-user-dev-server.js
+++ b/multi-user-dev-server.js
@@ -128,8 +128,14 @@ function createDevServer(optionsFromUsername, expireUnusedAfterSeconds) {
       res.status(200);
       res.send(options.successResponse || 'bundle built');
     }, err => {
+      const errorInfo = {
+         stack: err && err.stack,
+         details: err && err.details,
+         err: err,
+         errAsString: String(err),
+      }
       res.status(504);
-      res.send(JSON.stringify(err));
+      res.send(JSON.stringify(errorInfo));
     });
   });
 


### PR DESCRIPTION
Turns out:

JSON.stringify(new Error("Ohno!!")) === "{}"

So, just stringifying an error doesn't get us anything useful.

I took the logic of what can be extracted from errors from here:
https://webpack.js.org/api/node/#error-handling

There might be more, but this is a good start.