### PR TITLE
Child Process: stream stderr/out to a log file

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -4,6 +4,7 @@ const app = multiUserDevServer(username => {
   return {
     // The path to this user's webpack config
     configPath: `${__dirname}/${username}/webpack.config.js`,
+    logPath: `${__dirname}/${username}/webpack.log`,
     // The `env` to pass into the webpack config
     webpackEnv: {},
     // What to respond with for `GET /:username` (optional)

--- a/webpack-compiler.js
+++ b/webpack-compiler.js
@@ -31,14 +31,19 @@ function getWebpack(options, watchOptions) {
    return webpack(config).watch(watchOptions, (err, stats) => {
       const endTime = stats && stats.endTime;
       // let the parent know we built our bundle
-      process.send({event: 'built', err, stats: {endTime: endTime}});
-      errFromPreviousBuild = err;
       if (err) {
          console.error("build failed at: " + timestamp(endTime));
          console.error(err);
+      } else if (stats && stats.compilation && stats.compilation.errors.length) {
+         err = "Build failed";
+         console.error("build failed at: " + timestamp(endTime));
+         console.error(stats.compilation.errors);
       } else {
-         console.log("built at: " + timestamp(endTime));
+         console.log("build succeeded at: " + timestamp(endTime));
       }
+
+      process.send({event: 'built', err, stats: {endTime: endTime}});
+      errFromPreviousBuild = err;
    });
 }
 

--- a/webpack-compiler.js
+++ b/webpack-compiler.js
@@ -29,8 +29,19 @@ function getWebpack(options, watchOptions) {
    const getWebpackConfig = require(options.configPath);
    const config = getWebpackConfig(options.webpackEnv || {});
    return webpack(config).watch(watchOptions, (err, stats) => {
+      const endTime = stats && stats.endTime;
       // let the parent know we built our bundle
-      process.send({event: 'built', err, stats: {endTime: stats && stats.endTime}});
+      process.send({event: 'built', err, stats: {endTime: endTime}});
       errFromPreviousBuild = err;
+      if (err) {
+         console.error("build failed at: " + timestamp(endTime));
+         console.error(err);
+      } else {
+         console.log("built at: " + timestamp(endTime));
+      }
    });
+}
+
+function timestamp(timestampMs){
+   return (new Date(timestampMs)).toLocaleString();
 }

--- a/webpack-watcher.js
+++ b/webpack-watcher.js
@@ -24,6 +24,11 @@ module.exports = (options) => {
    });
 
    function notifyWatchers(err) {
+      if ((typeof err) == 'string') {
+         const log = options.logPath ? ": " + options.logPath : "";
+         err = err + ". Check the log" + log;
+      }
+
       if (watchers.length) {
          const success = err ? " has failed" : " has succeeded";
       }
@@ -42,7 +47,7 @@ module.exports = (options) => {
          if (child.connected) {
             child.send({event: 'isRunning'})
          } else {
-            notifyWatchers("Webpack child process crashed, check the log");
+            notifyWatchers("Webpack child process crashed");
          }
       })
    }
@@ -75,7 +80,7 @@ module.exports = (options) => {
    function listenForExit(child) {
       child.on('exit', function(code) {
          console.log("Process for " + options.username + " stopped with exit code: " + code);
-         notifyWatchers("Webpack child process crashed, check the log");
+         notifyWatchers("Webpack child process crashed");
       });
    }
 

--- a/webpack-watcher.js
+++ b/webpack-watcher.js
@@ -2,7 +2,7 @@ const childProcess = require('child_process');
 
 module.exports = (options) => {
    console.log("Forking " + options.username);
-   const child = childProcess.fork(__dirname + '/webpack-compiler.js')
+   const child = forkCompiler();
 
    let onBundled = () => {}
    const watchers = new Set();
@@ -40,6 +40,10 @@ module.exports = (options) => {
          watchers.add({resolve, reject});
          child.send({event: 'isRunning'})
       })
+   }
+
+   function forkCompiler() {
+      return childProcess.fork(__dirname + '/webpack-compiler.js');
    }
 
    return {


### PR DESCRIPTION
* Allow users of this module to specify a log file that
  should receive stdout / stderr from the webpack process
   * If it crashes, we'll actually have the output
* If the webpack proc crashes, notify the watchers
* Respond quickly if trying to ask the child a question
  when it's dead.

CC @jarstelfox

Closes #12