### PR TITLE
Watcher process: title based on username

### DIFF
--- a/webpack-compiler.js
+++ b/webpack-compiler.js
@@ -26,6 +26,9 @@ process.on('message', (message) => {
 });
 
 function getWebpack(options, watchOptions) {
+   if (options.username) {
+      process.title = "webpack-watcher for " + options.username;
+   }
    const getWebpackConfig = require(options.configPath);
    const config = getWebpackConfig(options.webpackEnv || {});
    return webpack(config).watch(watchOptions, (err, stats) => {


### PR DESCRIPTION
Previously, all proc titles would match the parent. This could be
confusing when looking at a list of ~10 processes with all the same
tile.