### PR TITLE
Fork webpack compiler using UID of calling user

### DIFF
--- a/webpack-watcher.js
+++ b/webpack-watcher.js
@@ -3,7 +3,8 @@ const fs = require('fs');
 
 module.exports = (options) => {
    console.log("Forking " + options.username);
-   const child = forkCompiler();
+   const uid = Number(childProcess.execSync(`id -u ${options.username}`, { encoding: 'utf-8' }));
+   const child = forkCompiler(uid);
 
    let onBundled = () => {}
    const watchers = new Set();
@@ -52,18 +53,19 @@ module.exports = (options) => {
       })
    }
 
-   function forkCompiler() {
-      const forkOptions = getForkOptions();
+   function forkCompiler(uid) {
+      const forkOptions = getForkOptions(uid);
       const child = childProcess.fork(__dirname + '/webpack-compiler.js', forkOptions)
       logOutput(child);
       listenForExit(child);
       return child;
    }
 
-   function getForkOptions() {
+   function getForkOptions(uid) {
       const output = options.logPath ? 'pipe' : 'inherit';
       return {
-         stdio: ['inherit', output, output, 'ipc']
+         stdio: ['inherit', output, output, 'ipc'],
+         uid,
       };
    }
 


### PR DESCRIPTION
This causes all the generated files to be owned by that user, which prevents the need to use `sudo` to delete them, when the `webpack-watcher` is running as `root`.

QA
---
1. Clone this repo for yourself.
2. Run `npm link` in your clone.
3. Go to your normal code directory. Run `npm link multi-user-dev-server`.
4. Update all the places where your code uses port `7358` to use another port number of your choosing.
5. Start a private copy of the dev server, using `./Exec/AssetBuild/webpack-dev`.
6. Check that the JS builds and that the site loads.
7. Check that the `scripts` directory in your asset build output is owned by your user.

Closes #17
