### PR TITLE
Use the user's `gid` for the new process's `gid`

### DIFF
--- a/webpack-compiler.js
+++ b/webpack-compiler.js
@@ -2,6 +2,8 @@
 // messages with the parent process.
 const webpack = require("webpack");
 
+process.umask(0o002);
+
 var watcher = null;
 let errFromPreviousBuild = null;
 

--- a/webpack-watcher.js
+++ b/webpack-watcher.js
@@ -4,7 +4,8 @@ const fs = require('fs');
 module.exports = (options) => {
    console.log("Forking " + options.username);
    const uid = Number(childProcess.execSync(`id -u ${options.username}`, { encoding: 'utf-8' }));
-   const child = forkCompiler(uid);
+   const gid = Number(childProcess.execSync(`id -g ${options.username}`, { encoding: 'utf-8' }));
+   const child = forkCompiler(uid, gid);
 
    let onBundled = () => {}
    const watchers = new Set();
@@ -53,19 +54,20 @@ module.exports = (options) => {
       })
    }
 
-   function forkCompiler(uid) {
-      const forkOptions = getForkOptions(uid);
+   function forkCompiler(uid, gid) {
+      const forkOptions = getForkOptions(uid, gid);
       const child = childProcess.fork(__dirname + '/webpack-compiler.js', forkOptions)
       logOutput(child);
       listenForExit(child);
       return child;
    }
 
-   function getForkOptions(uid) {
+   function getForkOptions(uid, gid) {
       const output = options.logPath ? 'pipe' : 'inherit';
       return {
          stdio: ['inherit', output, output, 'ipc'],
          uid,
+         gid,
       };
    }
 


### PR DESCRIPTION
Without this, the process isn't allowed to read or write files which the user's group is allowed to read or write.

We ran into a problem where the parent directory of our webpack output directory only had write permissions for `apache` and `coders`, and the process (unlike all our users) didn't have the `coders` group, so it couldn't write the directory.

This also sets the process umask to allow files to be created with the group-writable bit set.